### PR TITLE
Address unreliable pico on cold boot.

### DIFF
--- a/pico/CMakeLists.txt
+++ b/pico/CMakeLists.txt
@@ -24,6 +24,8 @@ add_compile_options(-Wall
 add_compile_definitions(GIT_VERSION_STR_POSTFIX="-${GITVER}")
 message( STATUS "GIT_VERSION_STR_POSTFIX: ${GITVER}" )
 
+add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
+
 add_executable(cm4-wrt-a
         cm4-wrt-a.c
         pico_pkt_ping.c


### PR DESCRIPTION
One of the boards would not boot unless I reset the pico.

Apparently this is due to a slow oscillator start. Adding this define allows it to reliably boot from power-on.

See here: https://forums.raspberrypi.com/viewtopic.php?t=368080
And Here: https://forums.raspberrypi.com/viewtopic.php?t=355415